### PR TITLE
Maintain compatibility with new ray version

### DIFF
--- a/puppersim/pupper_ars_train.py
+++ b/puppersim/pupper_ars_train.py
@@ -504,7 +504,7 @@ if __name__ == '__main__':
 
 
     print("redis_address=", args.redis_address)
-    ray.init(redis_address=args.redis_address)
+    ray.init(address=args.redis_address)
  
     params = vars(args)
     run_ars(params)

--- a/puppersim/pupper_ars_train.py
+++ b/puppersim/pupper_ars_train.py
@@ -10,6 +10,7 @@ import time
 import os
 import numpy as np
 import gym
+from packaging import version
 
 import arspb.logz as logz
 import ray
@@ -504,7 +505,10 @@ if __name__ == '__main__':
 
 
     print("redis_address=", args.redis_address)
-    ray.init(address=args.redis_address)
+    if version.parse(ray.__version__) >= version.parse("1.6.0"):
+      ray.init(address=args.redis_address)
+    else:
+      ray.init(redis_address=args.redis_address)
  
     params = vars(args)
     run_ars(params)


### PR DESCRIPTION
Ray v1.6.0 no longer has `ray.init(redis_address=blah)`. It's replaced by `ray.init(address=blah)`. 