### PR TITLE
Bug Fix: Change redis_address to address to match ray.init param name

### DIFF
--- a/puppersim/pupper_ars_train.py
+++ b/puppersim/pupper_ars_train.py
@@ -504,7 +504,7 @@ if __name__ == '__main__':
 
 
     print("redis_address=", args.redis_address)
-    ray.init(redis_address=args.redis_address)
+    ray.init(address=args.redis_address)
  
     params = vars(args)
     run_ars(params)


### PR DESCRIPTION
Not sure if this is correct, but I was encountering an error and this returns param name to previous name. 