### PR TITLE
Fix policy loop rate. Increase PD gains to reduce sim2real gap

### DIFF
--- a/puppersim/config/pupper_pmtg.gin
+++ b/puppersim/config/pupper_pmtg.gin
@@ -6,6 +6,7 @@ import pybullet_envs.minitaur.envs_v2.scenes.scene_base
 import pybullet_envs.minitaur.envs_v2.scenes.simple_scene
 import pybullet_envs.minitaur.envs_v2.sensors.imu_sensor
 import pybullet_envs.minitaur.envs_v2.sensors.motor_angle_sensor
+import pybullet_envs.minitaur.robots.robot_urdf_loader
 
 import puppersim.pupper_motor_model
 import puppersim.pupper_constants
@@ -43,9 +44,12 @@ locomotion_gym_config.LocomotionGymConfig.simulation_parameters = @locomotion_gy
 locomotion_gym_env.LocomotionGymEnv.gym_config = @locomotion_gym_config.LocomotionGymConfig()
 
 # Specify the scene.
+# robot_urdf_loader.RobotUrdfLoader.constrained_base = True
+# robot_urdf_loader.RobotUrdfLoader.init_base_position = (0,0, 1.0)
 
-# locomotion_gym_env.LocomotionGymEnv.scene = @simple_scene.SimpleScene()
+# locomotion_gym_env.LocomotionGymEnv.scene = None
 locomotion_gym_env.LocomotionGymEnv.scene = @pupper_randomized_ground.BumpyScene()
+
 pupper_randomized_ground.BumpyScene.lateral_friction=1.8
 pupper_randomized_ground.BumpyScene.height_perturbation_range=0.03
 

--- a/puppersim/config/pupper_pmtg_robot.gin
+++ b/puppersim/config/pupper_pmtg_robot.gin
@@ -5,6 +5,7 @@ import pybullet_envs.minitaur.envs_v2.locomotion_gym_env
 import pybullet_envs.minitaur.envs_v2.scenes.scene_base
 import pybullet_envs.minitaur.envs_v2.scenes.simple_scene
 import pybullet_envs.minitaur.envs_v2.sensors.motor_angle_sensor
+import pybullet_envs.minitaur.envs_v2.sensors.imu_sensor
 
 import puppersim.pupper_motor_model
 import puppersim.pupper_constants
@@ -35,7 +36,7 @@ imu_sensor.IMUSensor.upper_bound = [6.28318548203, 6.28318548203,
                                        6283.18554688, 6283.18554688]
 
 # We use the default confirugration for MotorAngleSensor, which reads limits from the robot.
-SENSORS = [@imu_sensor.IMUSensor(), @motor_angle_sensor.MotorAngleSensor()]
+SENSORS = [@motor_angle_sensor.MotorAngleSensor()]
 locomotion_gym_config.SimulationParameters.sim_time_step_s = %SIM_TIME_STEP
 locomotion_gym_config.SimulationParameters.num_action_repeat = %NUM_ACTION_REPEAT
 locomotion_gym_config.SimulationParameters.enable_rendering = False
@@ -57,8 +58,8 @@ robot_config.MotorLimits.angle_upper_limits = %pupper_constants.MOTOR_ACTION_UPP
 robot_config.MotorLimits.torque_lower_limits = -1.7
 robot_config.MotorLimits.torque_upper_limits = 1.7
 
-pupper_robot_v2.PupperRobot.kp = 16.0 # [A/rad]
-pupper_robot_v2.PupperRobot.kp = 2.0 # [A/(rad/s)]
+pupper_robot_v2.PupperRobot.kp = 50.0 # [A/rad]
+pupper_robot_v2.PupperRobot.kd = 5.0 # [A/(rad/s)]
 pupper_robot_v2.PupperRobot.max_current = 7.0 # [A]
 pupper_robot_v2.PupperRobot.motor_limits = @robot_config.MotorLimits()
 pupper_robot_v2.PupperRobot.motor_control_mode = %robot_config.MotorControlMode.POSITION
@@ -83,7 +84,7 @@ pmtg_wrapper_env.PmtgWrapperEnv.action_filter_enable = True
 pmtg_wrapper_env.PmtgWrapperEnv.intensity_upper_bound = 1.0
 pmtg_wrapper_env.PmtgWrapperEnv.max_delta_time = 4.0
 pmtg_wrapper_env.PmtgWrapperEnv.min_delta_time = 2.0
-pmtg_wrapper_env.PmtgWrapperEnv.residual_range = 0.1
+pmtg_wrapper_env.PmtgWrapperEnv.residual_range = 0.5
 pmtg_wrapper_env.PmtgWrapperEnv.integrator_coupling_mode = "all coupled"
 pmtg_wrapper_env.PmtgWrapperEnv.walk_height_coupling_mode = "all coupled"
 pmtg_wrapper_env.PmtgWrapperEnv.variable_swing_stance_ratio = 1

--- a/puppersim/pupper_ars_run_policy.py
+++ b/puppersim/pupper_ars_run_policy.py
@@ -123,30 +123,32 @@ def main(argv):
     steps = 0
     start_time = env.robot.GetTimeSinceReset()
     current_time = start_time
-    last_loop = time.time()
-    while not done:
-      start_time_robot = current_time
-      start_time_wall = time.time()
-      before_policy = time.time()
-      action = policy.act(obs)
-      after_policy = time.time()
+    start_time_wall = time.time()
+    while not done or args.run_on_robot:
+      if time.time() - start_time_wall > 0.01:
+        if args.profile:
+          print("loop dt:", time.time() - start_time_wall)
+        start_time_robot = current_time
+        start_time_wall = time.time()
+        before_policy = time.time()
+        action = policy.act(obs)
+        after_policy = time.time()
 
-      if not args.run_on_robot:
-        observations.append(obs)
-        actions.append(action)
+        if not args.run_on_robot:
+          observations.append(obs)
+          actions.append(action)
 
-      obs, r, done, _ = env.step(action)
-      totalr += r
-      steps += 1
-      current_time = env.robot.GetTimeSinceReset()
-      expected_duration = current_time - start_time_robot
-      actual_duration = time.time() - start_time_wall
-      if not args.nosleep and actual_duration < expected_duration and not args.run_on_robot:
-        time.sleep(expected_duration - actual_duration)
-      if args.profile:
-        print('policy.act(obs): ', after_policy - before_policy)
-        print('wallclock_loop_dt: ', time.time() - last_loop)
-      last_loop = time.time()
+        obs, r, done, _ = env.step(action)
+        totalr += r
+        steps += 1
+        current_time = env.robot.GetTimeSinceReset()
+        expected_duration = current_time - start_time_robot
+        actual_duration = time.time() - start_time_wall
+        if not args.nosleep and actual_duration < expected_duration and not args.run_on_robot:
+          time.sleep(expected_duration - actual_duration)
+        if args.profile:
+          print('policy.act(obs): ', after_policy - before_policy)
+          print('wallclock_control_code: ', time.time() - start_time_wall)
     returns.append(totalr)
 
   print('returns: ', returns)

--- a/puppersim/pupper_ars_run_policy.py
+++ b/puppersim/pupper_ars_run_policy.py
@@ -47,7 +47,6 @@ def main(argv):
   import argparse
   parser = argparse.ArgumentParser()
   parser.add_argument('--expert_policy_file', type=str, default="data/lin_policy_plus_latest.npz", help='relative path to the policy weights. Defaults to where ars_train outputs weight file.')
-  parser.add_argument('--nosleep', action='store_true', help='whether to sleep during the control loop to make it realtime. Does not apply to running on the robot. Default is False.')
 
   parser.add_argument('--num_rollouts', type=int, default=20,
                       help='Number of expert rollouts. Default is 20.')
@@ -121,14 +120,11 @@ def main(argv):
     done = False
     totalr = 0.
     steps = 0
-    start_time = env.robot.GetTimeSinceReset()
-    current_time = start_time
     start_time_wall = time.time()
     while not done or args.run_on_robot:
-      if time.time() - start_time_wall > 0.01:
+      if time.time() - start_time_wall > env.env_time_step:
         if args.profile:
           print("loop dt:", time.time() - start_time_wall)
-        start_time_robot = current_time
         start_time_wall = time.time()
         before_policy = time.time()
         action = policy.act(obs)
@@ -141,11 +137,6 @@ def main(argv):
         obs, r, done, _ = env.step(action)
         totalr += r
         steps += 1
-        current_time = env.robot.GetTimeSinceReset()
-        expected_duration = current_time - start_time_robot
-        actual_duration = time.time() - start_time_wall
-        if not args.nosleep and actual_duration < expected_duration and not args.run_on_robot:
-          time.sleep(expected_duration - actual_duration)
         if args.profile:
           print('policy.act(obs): ', after_policy - before_policy)
           print('wallclock_control_code: ', time.time() - start_time_wall)


### PR DESCRIPTION
Run the control loop every 0.01s (or whatever determined by action_repeat) via busy waiting.
Revert pd gains to kp=50, kd=5. Gives much more realistic sim2real than kp=16, kd=2. 